### PR TITLE
fix showing first day of week in week view

### DIFF
--- a/fullcalendar.js
+++ b/fullcalendar.js
@@ -7995,11 +7995,12 @@ var View = FC.View = Class.extend(EmitterMixin, ListenerMixin, {
 	// Subclasses can override. Must return all properties.
 	computeRange: function(date) {
 		var intervalUnit = computeIntervalUnit(this.intervalDuration);
-		var intervalStart = date.clone().startOf(toJalaaliUnit(intervalUnit,this.isJalaali));
 		if (this.isJalaali && ( intervalUnit === "year" || intervalUnit === "month")) {
+			var intervalStart = date.clone().startOf(toJalaaliUnit(intervalUnit, this.isJalaali));
 			var intervalEnd = intervalStart.clone().add(1,toJalaaliUnit(intervalUnit,this.isJalaali));
 		}
 		else {
+			var intervalStart = date.clone().startOf(intervalUnit);
 			var intervalEnd = intervalStart.clone().add(this.intervalDuration);
 		}
 		var start, end;


### PR DESCRIPTION
Hey there.
I had been using your full calendar in a project. Found out that in week's view, there is a problem, that it shows the current day as the first day of the week. First I thought I was passing the arguments wrong, but the first day was showing correct in month view.

Checked the code, and found out that there is a bug. So here is the fix